### PR TITLE
fix: Add a default value for ACL configuration

### DIFF
--- a/acls.tf
+++ b/acls.tf
@@ -1,5 +1,5 @@
 resource "scaleway_rdb_acl" "this" {
-  for_each = local.databases
+  for_each = { for database, config in local.databases : database => config if length(config.acls) > 0 }
 
   instance_id = scaleway_rdb_instance.this[each.key].id
 

--- a/locals.tf
+++ b/locals.tf
@@ -28,6 +28,7 @@ locals {
     node_type = "DB-DEV-S"
     users     = []
     settings  = {}
+    acls      = []
   }
   databases = {
     for database_name, config in var.databases :

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "this" {
     for name in keys(var.databases) : name => {
       "instance" = scaleway_rdb_instance.this[name],
       "database" = scaleway_rdb_database.this[name],
-      "acls"     = scaleway_rdb_acl.this[name],
+      "acls"     = lookup(scaleway_rdb_acl.this, name, []),
       "users" = [
         for identifier, config in local.user_by_database : {
           "username" : config.user.username,


### PR DESCRIPTION
# Add a default value for ACL configuration

## Description

#5 broke the `simple` example by making the `.acls` attribute of the `database` entity a requirement.

Add a default to `[]`.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
