### PR TITLE
feat(instance): variabilize instance resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,12 +5,25 @@ resource "scaleway_rdb_database" "this" {
 }
 
 resource "scaleway_rdb_instance" "this" {
-  for_each       = local.databases
-  name           = each.value.name
-  node_type      = lower(each.value.node_type)
-  engine         = each.value.engine
+  for_each = local.databases
+
+  name      = each.value.name
+  node_type = lower(each.value.node_type)
+
+  engine   = each.value.engine
+  settings = lookup(each.value, "settings", {})
+
+  user_name = lookup(each.value, "user_name", null)
+  password  = lookup(each.value, "password", null)
+
   is_ha_cluster  = lookup(each.value, "is_ha_cluster", true)
   disable_backup = lookup(each.value, "disable_backup", false)
-  tags           = lookup(each.value, "tags", [])
-  settings       = lookup(each.value, "settings", {})
+
+  volume_type       = lookup(each.value, "volume_type", "lssd")
+  volume_size_in_gb = lookup(each.value, "volume_size_in_gb", null)
+
+  region     = lookup(each.value, "region", null)
+  project_id = lookup(each.value, "project_id", null)
+
+  tags = lookup(each.value, "tags", [])
 }


### PR DESCRIPTION
# Variabilize instance configuration

## Description

Allow to configure every argument of the terraform resource
scaleway_rdb_instance.

- Configure auth (`user_name`, `password`)
- Configure storage (`volume_type`, `volume_size_in_gb`)
- Configure `settings`
- Specify `region` and `project_id` (defaults to provider)

Closes #8

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
