### PR TITLE
feat(outputs): add `databases` and `instances` by database

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,5 +134,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_databases"></a> [databases](#output\_databases) | A map of each created scaleway\_rdb\_instance with each `var.databases` definition as key |
+| <a name="output_instances"></a> [instances](#output\_instances) | A map of each created scaleway\_rdb\_instance with each `var.databases` definition as key |
 | <a name="output_this"></a> [this](#output\_this) | A map of the scaleway\_rdb\_database (including their users) and scaleway\_rdb\_instance resources grouped by databases definitions |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/databases/README.md
+++ b/examples/databases/README.md
@@ -48,5 +48,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_databases"></a> [databases](#output\_databases) | n/a |
+| <a name="output_instances"></a> [instances](#output\_instances) | n/a |
 | <a name="output_rdb"></a> [rdb](#output\_rdb) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/databases/main.tf
+++ b/examples/databases/main.tf
@@ -19,3 +19,12 @@ output "rdb" {
   value     = module.rdb.this
   sensitive = true
 }
+
+output "instances" {
+  value     = module.rdb.instances
+  sensitive = true
+}
+
+output "databases" {
+  value = module.rdb.databases
+}

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -45,5 +45,6 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_instances"></a> [instances](#output\_instances) | n/a |
 | <a name="output_rdb"></a> [rdb](#output\_rdb) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -16,3 +16,8 @@ output "rdb" {
   value     = module.rdb.this
   sensitive = true
 }
+
+output "instances" {
+  value     = module.rdb.instances
+  sensitive = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,3 +21,18 @@ output "this" {
   description = "A map of the scaleway_rdb_database (including their users) and scaleway_rdb_instance resources grouped by databases definitions"
   sensitive   = true
 }
+
+output "instances" {
+  value = {
+    for name in keys(var.databases) : name => scaleway_rdb_instance.this[name]
+  }
+  description = "A map of each created scaleway_rdb_instance with each `var.databases` definition as key"
+}
+
+output "databases" {
+  value = {
+    for identifier, config in local.dbs_by_database :
+    scaleway_rdb_database.this[identifier].config.database => scaleway_rdb_database.this[config.database]
+  }
+  description = "A map of each created scaleway_rdb_instance with each `var.databases` definition as key"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,7 +32,7 @@ output "instances" {
 output "databases" {
   value = {
     for identifier, config in local.dbs_by_database :
-    scaleway_rdb_database.this[identifier].config.database => scaleway_rdb_database.this[config.database]
+    config.database => scaleway_rdb_database.this[identifier]...
   }
   description = "A map of each created scaleway_rdb_instance with each `var.databases` definition as key"
 }


### PR DESCRIPTION
# Add instances and databases outputs

## Description

- feat(outputs): create `instances` and `databases`
- doc(example): use `instances` output
- fix(outputs): group databases by rdb
- doc(example): use `databases` output


```console
$ terraform output instances
{
  "main" = {
    "certificate" = <<-EOT
        REDACTED
    EOT
    "disable_backup" = false
    "endpoint_ip" = "REDACTED"
    "endpoint_port" = 38056
    "engine" = "PostgreSQL-11"
    "id" = "REDACTED"
    "is_ha_cluster" = true
    "name" = "test-simple-db"
    "node_type" = "db-dev-s"
    "organization_id" = ""
    "password" = ""
    "project_id" = ""
    "read_replicas" = tolist([])
    "region" = "fr-par"
    "settings" = tomap({
      "effective_cache_size" = "1300"
      "maintenance_work_mem" = "150"
      "max_connections" = "100"
      "max_parallel_workers" = "0"
      "max_parallel_workers_per_gather" = "0"
      "work_mem" = "4"
    })
    "tags" = tolist([])
    "timeouts" = null /* object */
    "user_name" = ""
    "volume_size_in_gb" = 5
    "volume_type" = "lssd"
  }
}
```


### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
