### PR TITLE
feat(net): add support for private_network

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -42,6 +42,8 @@ locals {
     settings  = {}
     acls      = []
     dbs       = []
+
+    private_network = {}
   }
   databases = {
     for database_name, config in var.databases :

--- a/main.tf
+++ b/main.tf
@@ -20,4 +20,13 @@ resource "scaleway_rdb_instance" "this" {
   project_id = lookup(each.value, "project_id", null)
 
   tags = lookup(each.value, "tags", [])
+
+  dynamic "private_network" {
+    for_each = lookup(each.value, "private_network", {}) != {} ? [1] : []
+
+    content {
+      ip_net = lookup(each.value.private_networking, "ip_net", null)
+      pn_id  = lookup(each.value.private_networking, "pn_id", null)
+    }
+  }
 }


### PR DESCRIPTION
# Add support for private networking for rdb_instances

## Description

Specify a dynamic `private_network` block for `rdb_instance.this`.

Closes #15

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/particuleio/terraform-kubernetes-addons/#doc-generation
